### PR TITLE
Allow Dictionary for axislabel in coord_params for Customization

### DIFF
--- a/mpl_animators/wcs.py
+++ b/mpl_animators/wcs.py
@@ -179,7 +179,11 @@ class ArrayAnimatorWCS(ArrayAnimator):
 
             axislabel = params.get("axislabel", None)
             if axislabel:
-                coord.set_axislabel(axislabel)
+                if isinstance(axislabel, dict):
+                   coord.set_axislabel(axislabel)
+                else:
+        # Default behavior for a string label
+                   coord.set_axislabel(axislabel)
 
             grid = params.get("grid", None)
             if grid is not None:


### PR DESCRIPTION
## PR Description

Modified the handling of axislabel in the coord_params dictionary.
Allowed axislabel to be a string or a dictionary.
If a dictionary is provided, it unpacks and passes the parameters to the set_axislabel method, enhancing flexibility for label customization.

Previously, the `axislabel` in `coord_params` only allowed passing a simple string to set the axis label.
With the new enhancement, axislabel can now accept a dictionary, which provides flexibility to include additional properties (e.g., color, font size, and other keyword arguments supported by `set_axislabel`).
line 181 added
```
if axislabel:
                if isinstance(axislabel, dict):
                   coord.set_axislabel(axislabel)
                else:
```
