### PR TITLE
Draw issues with jupyter lab and %matplotlib widget

### DIFF
--- a/changelog/129.bugfix.rst
+++ b/changelog/129.bugfix.rst
@@ -1,0 +1,1 @@
+Switched the backend to use ``draw_idle`` to avoid Jupyter lab widget issues.

--- a/mpl_animators/base.py
+++ b/mpl_animators/base.py
@@ -257,12 +257,12 @@ class BaseFuncAnimator(metaclass=abc.ABCMeta):
     def _highlight_slider(self, ind):
         ax = self.sliders[ind]
         [a.set_linewidth(2.0) for n, a in ax.spines.items()]
-        self.fig.canvas.draw()
+        self.fig.canvas.draw_idle()
 
     def _dehighlight_slider(self, ind):
         ax = self.sliders[ind]
         [a.set_linewidth(1.0) for n, a in ax.spines.items()]
-        self.fig.canvas.draw()
+        self.fig.canvas.draw_idle()
 
 # =============================================================================
 #   Build the figure and place the widgets


### PR DESCRIPTION
## PR Description

I was hitting issues with jupyter lab and using the matplotlib widget backend.

If I did multiple plots, I would hit the following error:

```python
[/home/nabil/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/ndcube/visualization/mpl_plotter.py:261](http://localhost:8888/home/nabil/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/ndcube/visualization/mpl_plotter.py#line=260): NDCubeUserWarning: Animating a NDCube does not support transposing the array. The world axes may not display as expected because the array will not be transposed.
  warn_user(
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[8], line 1
----> 1 cube["Mg II k 2796"][0].plot(plot_axes=["x","y",None],aspect="auto")

File [~/Git/irispy/irispy/spectrograph.py:160](http://localhost:8888/home/nabil/Git/irispy/irispy/spectrograph.py#line=159), in SpectrogramCube.plot(self, slider_labels, *args, **kwargs)
    158 if slider_labels is not None:
    159     kwargs["slider_labels"] = slider_labels
--> 160 return finalize_iris_plot(IRISPlotter(ndcube=self).plot(*args, **kwargs), kwargs.get("axes_coordinates"))

File [~/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/ndcube/visualization/mpl_plotter.py:89](http://localhost:8888/home/nabil/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/ndcube/visualization/mpl_plotter.py#line=88), in MatplotlibPlotter.plot(self, axes, plot_axes, axes_coordinates, axes_units, data_unit, wcs, **kwargs)
     86         ax = self._plot_2D_cube(plot_wcs, axes, plot_axes, axes_coordinates,
     87                                 axes_units, data_unit, **kwargs)
     88     else:
---> 89         ax = self._animate_cube(plot_wcs, plot_axes=plot_axes,
     90                                 axes_coordinates=axes_coordinates,
     91                                 axes_units=axes_units, data_unit=data_unit, **kwargs)
     93 return ax

File [~/Git/irispy/irispy/visualization.py:298](http://localhost:8888/home/nabil/Git/irispy/irispy/visualization.py#line=297), in IRISPlotter._animate_cube(self, wcs, plot_axes, axes_coordinates, axes_units, data_unit, **kwargs)
    296 data, wcs, plot_axes, coord_params = self._prep_animate_args(wcs, plot_axes, axes_units, data_unit)
    297 with _suppress_wcs_nan_tick_formatting_warning():
--> 298     ax = IRISArrayAnimatorWCS(data, wcs, plot_axes, coord_params=coord_params, **kwargs)
    299     self._apply_axes_coordinates(ax.axes, axes_coordinates)
    300     for hidden in self._not_visible_coords(ax.axes, axes_coordinates):

File [~/Git/mpl-animators/mpl_animators/wcs.py:106](http://localhost:8888/home/nabil/Git/mpl-animators/mpl_animators/wcs.py#line=105), in ArrayAnimatorWCS.__init__(self, data, wcs, slices, coord_params, ylim, ylabel, clip_interval, **kwargs)
    103 slider_labels = kwargs.pop('slider_labels', self._compute_slider_labels_from_wcs(slices))
    104 slider_labels += extra_slider_labels
--> 106 super().__init__(data, image_axes=image_axes, axis_ranges=None,
    107                  slider_labels=slider_labels,
    108                  **kwargs)

File [~/Git/mpl-animators/mpl_animators/base.py:489](http://localhost:8888/home/nabil/Git/mpl-animators/mpl_animators/base.py#line=488), in ArrayAnimator.__init__(self, data, image_axes, axis_ranges, **kwargs)
    487 self.num_sliders = len(base_kwargs["slider_functions"])
    488 base_kwargs.update(kwargs)
--> 489 super().__init__(data, **base_kwargs)

File [~/Git/mpl-animators/mpl_animators/base.py:125](http://localhost:8888/home/nabil/Git/mpl-animators/mpl_animators/base.py#line=124), in BaseFuncAnimator.__init__(self, data, slider_functions, slider_ranges, fig, interval, colorbar, button_func, button_labels, start_image_func, slider_labels, **kwargs)
    123 self._make_axes_grid()
    124 self._add_widgets()
--> 125 self._set_active_slider(0)
    127 # Set the current axes to the main axes so commands like plt.ylabel() work.
    128 #
    129 # Only do this if figure has a manager, so directly constructed figures
    130 # (ie. via matplotlib.figure.Figure()) work.
    131 if hasattr(self.fig.canvas, "manager") and self.fig.canvas.manager is not None:

File [~/Git/mpl-animators/mpl_animators/base.py:253](http://localhost:8888/home/nabil/Git/mpl-animators/mpl_animators/base.py#line=252), in BaseFuncAnimator._set_active_slider(self, ind)
    252 def _set_active_slider(self, ind):
--> 253     self._dehighlight_slider(self.active_slider)
    254     self._highlight_slider(ind)
    255     self.active_slider = ind

File [~/Git/mpl-animators/mpl_animators/base.py:265](http://localhost:8888/home/nabil/Git/mpl-animators/mpl_animators/base.py#line=264), in BaseFuncAnimator._dehighlight_slider(self, ind)
    263 ax = self.sliders[ind]
    264 [a.set_linewidth(1.0) for n, a in ax.spines.items()]
--> 265 self.fig.canvas.draw()

File [~/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/matplotlib/backends/backend_webagg_core.py:191](http://localhost:8888/home/nabil/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/matplotlib/backends/backend_webagg_core.py#line=190), in FigureCanvasWebAggCore.draw(self)
    189     super().draw()
    190 finally:
--> 191     self.manager.refresh_all()

AttributeError: 'NoneType' object has no attribute 'refresh_all'
```

I asked an LLM and it said to replace the draw with draw_idle and that works for me.
The figure still updates and I don't get that error message anymore.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [X] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.

It says:

• draw() means “render now.”

  draw_idle() means “mark this figure as needing a redraw, and let the backend render it when the event loop is ready.”

  The practical differences:

  - canvas.draw() is synchronous. It immediately runs the backend’s full render path.
  - canvas.draw_idle() is deferred or coalesced by interactive backends. If you call it ten times quickly, the backend can render once.
  - draw() is useful when you need the rendered pixels/layout immediately.
  - draw_idle() is better for UI updates like changing slider spine widths, labels, artist data, etc.

  In your failure, draw() entered Matplotlib’s WebAgg draw path immediately, which did:

  self.manager.refresh_all()

  but self.manager was None, so it crashed.

  With draw_idle(), the widget backend schedules the redraw instead of forcing that WebAgg render path during animator construction. That is why it is the right fix here: highlighting the active slider does not need an
  immediate blocking render before the animator object even finishes initializing.
